### PR TITLE
refactor: replace deprecated copy API with Clipboard API

### DIFF
--- a/assets/js/html-format.js
+++ b/assets/js/html-format.js
@@ -65,52 +65,11 @@ function minifyHTML(html) {
 
 // Function to copy text to clipboard
 function copyToClipboard(text) {
-    // Use temporary textarea element
-    let textArea = document.createElement("textarea");
-    textArea.value = text;
-
-    // Make it readonly to be safe.
-    textArea.setAttribute('readonly', '');
-    // Hide it off-screen
-    textArea.style.position = 'absolute';
-    textArea.style.left = '-9999px';
-
-    document.body.appendChild(textArea);
-    textArea.focus();
-
-    // Check if the browser supports Clipboard API
-    if (navigator.clipboard && textArea.value) {
-      navigator.clipboard.writeText(textArea.value)
-        .then(() => {
-           // Success feedback (optional)
-           // alert('Copied!');
-        })
-        .catch(err => {
-          console.error('Clipboard API error:', err);
-          // Fallback for older browsers might be needed if Clipboard API fails
-          try {
-            textArea.select();
-            document.execCommand('copy');
-            // alert('Copied (fallback)!');
-          } catch (err2) {
-            console.error('Fallback copy error:', err2);
-            alert('Failed to copy. Please copy manually.');
-          }
-        });
-    } else {
-        // Fallback for browsers without Clipboard API
-        try {
-           textArea.select();
-           document.execCommand('copy');
-           // alert('Copied (fallback)!');
-        } catch (err) {
-          console.error('Fallback copy error:', err);
-          alert('Failed to copy. Please copy manually.');
-        }
+    if (!navigator.clipboard) {
+        alert('Clipboard API not supported in this browser.');
+        return Promise.reject(new Error('Clipboard API not supported'));
     }
-
-    // Clean up the temporary element
-    document.body.removeChild(textArea);
+    return navigator.clipboard.writeText(text);
 }
 
 
@@ -158,13 +117,17 @@ document.addEventListener('DOMContentLoaded', () => {
      if (copyBtn) {
         copyBtn.addEventListener('click', () => {
             if (outputTextArea && outputTextArea.value) {
-                copyToClipboard(outputTextArea.value);
-                // Optional: Provide user feedback
-                const originalText = copyBtn.textContent;
-                copyBtn.textContent = 'Copied!';
-                setTimeout(() => {
-                    copyBtn.textContent = originalText;
-                }, 1500);
+                copyToClipboard(outputTextArea.value)
+                    .then(() => {
+                        const originalText = copyBtn.textContent;
+                        copyBtn.textContent = 'Copied!';
+                        setTimeout(() => {
+                            copyBtn.textContent = originalText;
+                        }, 1500);
+                    })
+                    .catch(() => {
+                        alert('Failed to copy to clipboard.');
+                    });
             }
         });
     }

--- a/assets/js/robotstxt.js
+++ b/assets/js/robotstxt.js
@@ -246,11 +246,10 @@
   function copy(){
     const txt = output.textContent || '';
     if(!txt.trim()){ alert('Nothing to copy. Click Generate first.'); return; }
-    navigator.clipboard?.writeText(txt).then(()=>toast('Copied to clipboard ✅')).catch(()=>{
-      const ta = document.createElement('textarea');
-      ta.value = txt; document.body.appendChild(ta); ta.select();
-      try{ document.execCommand('copy'); toast('Copied to clipboard ✅'); } finally { ta.remove(); }
-    });
+    if(!navigator.clipboard){ toast('Clipboard API not supported.'); return; }
+    navigator.clipboard.writeText(txt)
+      .then(()=>toast('Copied to clipboard ✅'))
+      .catch(()=>toast('Failed to copy to clipboard ❌'));
   }
 
   function download(){

--- a/assets/js/text-replacer-min.js
+++ b/assets/js/text-replacer-min.js
@@ -231,23 +231,16 @@
     function copyResult() {
         const val = els.output.value;
         if (!val) return;
-        if (navigator.clipboard) {
-            navigator.clipboard.writeText(val).then(() => {
-                els.stats.textContent = 'Result copied to clipboard.';
-            }).catch(() => fallbackCopy(val));
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(val)
+                .then(() => {
+                    els.stats.textContent = 'Result copied to clipboard.';
+                })
+                .catch(() => {
+                    els.stats.textContent = 'Failed to copy. Please copy manually.';
+                });
         } else {
-            fallbackCopy(val);
-        }
-        function fallbackCopy(text) {
-            const ta = document.createElement('textarea');
-            ta.value = text;
-            document.body.appendChild(ta);
-            ta.select();
-            try {
-                document.execCommand('copy');
-                els.stats.textContent = 'Result copied to clipboard.';
-            } catch (e) { }
-            document.body.removeChild(ta);
+            els.stats.textContent = 'Clipboard API not supported.';
         }
     }
 


### PR DESCRIPTION
## Summary
- replace deprecated `document.execCommand('copy')` with `navigator.clipboard.writeText`
- add error handling for failed clipboard writes

## Testing
- `npm test` (fails: Could not read package.json)
- `npm run lint` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b48f374e00832d94b29146f6650709