### PR TITLE
Refactor AdSense loader with IntersectionObserver

### DIFF
--- a/assets/js/adsense-injector.js
+++ b/assets/js/adsense-injector.js
@@ -1,36 +1,55 @@
 // Grandmaster SEO Alchemist - Manual AdSense Injector v1.0
-function injectAds() {
+function initAds() {
   const adPlaceholders = document.querySelectorAll('.manual-adsense-ad');
-  adPlaceholders.forEach(placeholder => {
-    if (placeholder.childElementCount > 0) return; // Ad already loaded, do nothing
+  if (adPlaceholders.length === 0) return;
 
-    const adClient = placeholder.dataset.adClient;
-    const adSlot = placeholder.dataset.adSlot;
+  const firstPlaceholder = adPlaceholders[0];
+  const adClient = firstPlaceholder.dataset.adClient;
 
-    if (!adClient || !adSlot) {
-      console.error('AdSense placeholder is missing data-ad-client or data-ad-slot.');
-      return;
-    }
-
+  if (!document.querySelector('script[src*="adsbygoogle.js"]') && adClient) {
     const adScript = document.createElement('script');
     adScript.src = 'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=' + adClient;
     adScript.async = true;
     adScript.crossOrigin = 'anonymous';
-    
-    const adIns = document.createElement('ins');
-    adIns.className = 'adsbygoogle';
-    adIns.style.display = 'block';
-    adIns.dataset.adClient = adClient;
-    adIns.dataset.adSlot = adSlot;
-    adIns.dataset.adFormat = 'auto';
-    adIns.dataset.fullWidthResponsive = 'true';
+    document.head.appendChild(adScript);
+  }
 
-    placeholder.appendChild(adScript);
-    placeholder.appendChild(adIns);
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (!entry.isIntersecting) return;
 
-    (window.adsbygoogle = window.adsbygoogle || []).push({});
+      const placeholder = entry.target;
+      if (placeholder.childElementCount > 0) {
+        observer.unobserve(placeholder);
+        return;
+      }
+
+      const adClient = placeholder.dataset.adClient;
+      const adSlot = placeholder.dataset.adSlot;
+
+      if (!adClient || !adSlot) {
+        console.error('AdSense placeholder is missing data-ad-client or data-ad-slot.');
+        observer.unobserve(placeholder);
+        return;
+      }
+
+      const adIns = document.createElement('ins');
+      adIns.className = 'adsbygoogle';
+      adIns.style.display = 'block';
+      adIns.dataset.adClient = adClient;
+      adIns.dataset.adSlot = adSlot;
+      adIns.dataset.adFormat = 'auto';
+      adIns.dataset.fullWidthResponsive = 'true';
+
+      placeholder.appendChild(adIns);
+
+      (window.adsbygoogle = window.adsbygoogle || []).push({});
+      observer.unobserve(placeholder);
+    });
   });
+
+  adPlaceholders.forEach(placeholder => observer.observe(placeholder));
 }
 
 // Run after the page is fully loaded to avoid conflicts with React
-window.addEventListener('load', injectAds);
+window.addEventListener('load', initAds);


### PR DESCRIPTION
## Summary
- Append AdSense script once on page load
- Load ads when placeholders enter viewport via IntersectionObserver

## Testing
- `npm test` *(fails: could not read package.json)*
- `npm run lint` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b48f193e68832dbac6ce9f8a4ea402